### PR TITLE
feat: add --max-depth option to limit directory scan depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ contree
 
 ### Options
 - `-d, --dir <PATH>`: Specify the directory to scan (defaults to `.`).
+- `--max-depth <NUMBER>`: Maximum depth of directories to scan (relative to dir), unlimited if not specified.
 - `-g, --grep <PATTERN>`: Filter files by content matching a pattern (plain text or `/regex/` for regex).
 - `-i, --include <FILES>`: Comma-separated list of files to include (e.g., `file1.rs,file2.rs`).
 - `-D, --include-deps`: Include dependency files referenced in errors (Rust projects only).
@@ -79,7 +80,12 @@ contree
    cargo test | contree --include-deps
    ```
 
-4. Use Makefile targets:
+4. Scan a directory with a maximum depth of 2:
+   ```bash
+   contree --dir src --max-depth 2
+   ```
+
+5. Use Makefile targets:
    ```bash
    make run-grep GREP=transaction
    make run-include INCLUDE=src/main.rs


### PR DESCRIPTION
- Added `--max-depth <NUMBER>` CLI option to restrict the depth of directory scanning relative to the specified `--dir`
- Updated `print_project_files` function to accept and apply the `max_depth` parameter using `WalkBuilder::max_depth`
- Documented the new option and added an example in README.md