### PR TITLE
feat(contree-cli): add exclude arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ contree
 - `-i, --include <FILES>`: Comma-separated list of files to include (e.g., `file1.rs,file2.rs`).
 - `-D, --include-deps`: Include dependency files referenced in errors (Rust projects only).
 - `-o, --output <FILE>`: Write output to a file instead of stdout.
+- `-e, --exclude <FILES>`: Comma-separated list of specific files to exclude (e.g., `src/config.rs,tests/data.txt`). Paths should be relative to the scanned directory.
 
 ### Examples
 1. Scan the current directory and filter files containing "transaction":
@@ -79,7 +80,12 @@ contree
    cargo test | contree --include-deps
    ```
 
-4. Use Makefile targets:
+4. Exclude specific files:
+   ```bash
+   contree --exclude src/config.rs,tests/data.txt
+   ```
+
+5. Use Makefile targets:
    ```bash
    make run-grep GREP=transaction
    make run-include INCLUDE=src/main.rs


### PR DESCRIPTION
feat: Add --exclude flag to specify files to ignore

Introduces the `-e, --exclude` command-line flag to allow users to
specify individual files that should be excluded from the context
output.

This flag accepts a comma-separated list of file paths, similar to
the existing `--include` flag. 

The implementation canonicalizes both the provided exclude paths and
the paths encountered during the directory walk to ensure accurate
matching.

Updates the README.md with the new flag description and usage examples.

### Examples:
Exclude a single file:
`contree --exclude src/config.rs`
`contree --exclude config.rs` (also works)

Exclude multiple files, including one in a subdirectory:
`contree -e src/config.rs,tests/data/ignore_this.txt`